### PR TITLE
feat: add sparse variant

### DIFF
--- a/.changeset/purple-poets-relate.md
+++ b/.changeset/purple-poets-relate.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/calendar-component": patch
+---
+
+add sparse variant which omits years without events

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 			<acdh-ch-calendar>
 				<label>
 					<span>Select a year: </span>
-					<acdh-ch-calendar-year-picker></acdh-ch-calendar-year-picker>
+					<acdh-ch-calendar-year-picker data-variant="sparse"></acdh-ch-calendar-year-picker>
 				</label>
 				<acdh-ch-calendar-year></acdh-ch-calendar-year>
 			</acdh-ch-calendar>
@@ -50,7 +50,7 @@
 
 			const events = [
 				{ date: new Date(Date.UTC(2021, 8, 26)), label: "Mein Geburtstag", kind: "birthday" },
-				{ date: new Date(Date.UTC(2022, 8, 26)), label: "Mein Geburtstag", kind: "birthday" },
+				// { date: new Date(Date.UTC(2022, 8, 26)), label: "Mein Geburtstag", kind: "birthday" },
 				{ date: new Date(Date.UTC(2023, 8, 26)), label: "Mein Geburtstag", kind: "birthday" },
 				{ date: new Date(Date.UTC(2024, 8, 26)), label: "Mein Geburtstag", kind: "birthday" },
 				{ date: new Date(Date.UTC(2024, 8, 26)), label: "Geburtstagsparty", kind: "party" },

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 		</div>
 
 		<script type="module">
-			import { register } from "/src/main.ts";
+			import { register } from "/src/calendar.ts";
 			import de from "/src/i18n/de.json";
 
 			register();

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
 	"packageManager": "pnpm@9.3.0",
 	"main": "./dist/calendar.umd.cjs",
 	"module": "./dist/calendar.js",
-	"types": "./dist/main.d.ts",
+	"types": "./dist/calendar.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/main.d.ts",
+			"types": "./dist/calendar.d.ts",
 			"import": "./dist/calendar.js",
 			"require": "./dist/calendar.umd.cjs"
 		},

--- a/src/calendar.css
+++ b/src/calendar.css
@@ -24,6 +24,10 @@
 	margin: 0;
 }
 
+:where(acdh-ch-calendar-year-picker label input[type="radio"]:disabled + span) {
+	cursor: not-allowed;
+}
+
 :where(acdh-ch-calendar-year) {
 	align-items: start;
 	display: grid;

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -226,8 +226,6 @@ export class CalendarYearRadioGroup extends HTMLElement {
 		radioGroup.role = "radiogroup";
 
 		range(startYear, endYear).forEach((year) => {
-			if (this.variant === "sparse" && !eventsByDate.has(year)) return;
-
 			const label = document.createElement("label");
 
 			const input = document.createElement("input");
@@ -235,11 +233,18 @@ export class CalendarYearRadioGroup extends HTMLElement {
 			input.name = this.id;
 			input.value = String(year);
 
+			if (this.variant === "sparse" && !eventsByDate.has(year)) {
+				input.disabled = true;
+			}
+
 			const selected = year === currentYear;
 			input.checked = selected;
 
+			const span = document.createElement("span");
+			span.append(document.createTextNode(String(year)));
+
 			label.append(input);
-			label.append(document.createTextNode(String(year)));
+			label.append(span);
 
 			radioGroup.append(label);
 		});


### PR DESCRIPTION
this adds an option to the year picker to only display years which have events attached. years without events will be omitted in the "select" picker, and marked as disabled in the "radio group" picker.

this is configurable via `data-variant` attribute on the picker element, e.g.:

```html
<acdh-ch-calendar-year-picker data-variant="sparse"></acdh-ch-calendar-year-picker>
```

closes #2